### PR TITLE
New option 'session_timeout'

### DIFF
--- a/swftp/ftp/service.py
+++ b/swftp/ftp/service.py
@@ -149,7 +149,7 @@ def makeService(options):
     ftpfactory = FTPFactory(ftpportal)
     ftpfactory.welcomeMessage = c.get('ftp', 'welcome_message')
     ftpfactory.allowAnonymous = False
-    ftpfactory.timeOut = int(c.get('ftp', 'session_timeout'))
+    ftpfactory.timeOut = c.getint('ftp', 'session_timeout')
 
     signal.signal(signal.SIGUSR1, log_runtime_info)
     signal.signal(signal.SIGUSR2, log_runtime_info)


### PR DESCRIPTION
This option can help keep system resources when ftp handles a lot of connections. Default value for FTPFactory.timeOut is 600 seconds and it is very much, I suggest default value set to 60 sec.

Also, I think, need to add same option for sftp and update man and tests :-)

PS: option 'connection_timeout' hard to understand, there is set connection timeout for swift, but not for ftp session. I was able to figured it only from source.
