### PR TITLE
Fixed ftp command NLST without arguments.

### DIFF
--- a/swftp/ftp/server.py
+++ b/swftp/ftp/server.py
@@ -91,6 +91,12 @@ class SwftpFTPProtocol(FTP, object):
 
         return super(SwftpFTPProtocol, self).ftp_LIST(path)
 
+    def ftp_NLST(self, path=''):
+        """
+        Overwrite for fix http://twistedmatrix.com/trac/ticket/4258
+        """
+        return super(SwftpFTPProtocol, self).ftp_NLST(path)
+
     def cleanupDTP(self):
         """
         Overwrite cleanupDTP() for fix socket leak


### PR DESCRIPTION
Workaround for bug in twisted https://twistedmatrix.com/trac/ticket/4258

Because of this, some FTP-clients don't work.
