### PR TITLE
Close the connection when try to execute the command.

### DIFF
--- a/swftp/sftp/server.py
+++ b/swftp/sftp/server.py
@@ -47,6 +47,10 @@ class SwiftSession(object):
     def closed(self):
         pass
 
+    def execCommand(self, proto, command):
+        # Immediately Close the connection
+        self.avatar.conn.transport.transport.loseConnection()
+
 
 class SwiftFileTransferServer(FileTransferServer):
     client = None


### PR DESCRIPTION
And avoid error:

```
[SSHChannel session (0) on SSHService ssh-connection on SwiftSSHServerTransport,1,127.0.0.1] Unhandled Error
        Traceback (most recent call last):
          File "/usr/lib/python2.7/dist-packages/twisted/python/log.py", line 73, in callWithContext
            return context.call({ILogContext: newCtx}, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 118, in callWithContext
            return self.currentContext().callWithContext(ctx, func, *args, **kw)
          File "/usr/lib/python2.7/dist-packages/twisted/python/context.py", line 81, in callWithContext
            return func(*args,**kw)
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/channel.py", line 137, in requestReceived
            return f(data)
        --- <exception caught here> ---
          File "/usr/lib/python2.7/dist-packages/twisted/conch/ssh/session.py", line 68, in request_exec
            self.session.execCommand(pp, f)
        exceptions.AttributeError: 'SwiftSession' object has no attribute 'execCommand'
```
