### PR TITLE
Set hardlinks as count of objects in the container (only for account listing).

### DIFF
--- a/swftp/ftp/server.py
+++ b/swftp/ftp/server.py
@@ -35,7 +35,7 @@ def stat_format(keys, props):
         elif key == 'permissions':
             val = st.st_mode
         elif key == 'hardlinks':
-            val = 0
+            val = st.st_nlink
         elif key == 'modified':
             val = int(st.st_mtime)
         elif key in 'owner':


### PR DESCRIPTION
And avoid problem with Midnight Commander (Cannot parse error).
